### PR TITLE
add github page handler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ argparse==1.2.1
 gunicorn==18.0
 itsdangerous==0.24
 wsgiref==0.1.2
+PyGithub==1.25

--- a/shogun_web.py
+++ b/shogun_web.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, redirect
 from BeautifulSoup import BeautifulSoup
+from github import Github
 import os
 import urllib2, urllib
 import json
@@ -90,6 +91,14 @@ def irclog(date):
   return render_template('irclogs.html', log=log)
 
 
+@app.route('/shogun_readme')
+def shogun_readme():
+  github = Github()
+  md_content = get_github_file('https://raw.githubusercontent.com/shogun-toolbox/shogun/develop/README.md')
+  html_content = github.render_markdown(md_content)
+  return render_template('external_page.html', title="Shogun Readme", body=html_content)
+
+
 # utils
 def get_showcase():
   showcase = []
@@ -146,6 +155,16 @@ def recent_commits():
   except urllib2.HTTPError, e:
     print e
 
+
+# make sure to use the 'raw' file url
+def get_github_file(url):
+  request = urllib2.Request(url)
+
+  try:
+    response = urllib2.urlopen(request)
+    return response.read().decode('utf-8')
+  except urllib2.HTTPError, e:
+    print e
 
 def recent_tweets():
   url = "https://api.twitter.com/1.1/statuses/user_timeline.json"

--- a/templates/external_page.html
+++ b/templates/external_page.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {{ title }}
+{% endblock %}
+
+{% block content %}
+<div class="container pt">
+  {{ body|safe }}
+</div>
+{% endblock %}


### PR DESCRIPTION
closes #8 

you can see the page in action here: 
http://shogun-web.herokuapp.com/shogun_readme

Its not linked from anywhere and I don't know if this is even a page we would want this for, that's a discussion for what should be on the homepage. This is a proof of concept for fetching a github markdown file and rendering it on our site.

cc @iglesias if you have any comments on naming or structure let me know, otherwise I will merge this shortly. 
